### PR TITLE
fix: active window not detected for absolute paths outside cwd

### DIFF
--- a/lua/harpoon-lualine/init.lua
+++ b/lua/harpoon-lualine/init.lua
@@ -4,17 +4,23 @@ local harpoon = utils.lazy_require "harpoon"
 local M = {}
 
 M.status = function(options)
-    local list = harpoon:list()
-    local root_dir = list.config:get_root_dir()
+    local harpoon_entries = harpoon:list()
+    local root_dir = harpoon_entries.config:get_root_dir()
     local current_file_path = vim.api.nvim_buf_get_name(0)
 
-    local length = math.min(list:length(), #options.indicators)
+    local length = math.min(harpoon_entries:length(), #options.indicators)
 
     local status = {}
 
     for i = 1, length do
-        local value = list:get(i).value
-        local full_path = utils.get_full_path(root_dir, value)
+        local harpoon_path = harpoon_entries:get(i).value
+
+        local full_path = nil
+        if utils.is_relative_path(harpoon_path) then
+            full_path = utils.get_full_path(root_dir, harpoon_path)
+        else
+            full_path = harpoon_path
+        end
 
         if full_path == current_file_path then
             table.insert(status, options.active_indicators[i])

--- a/lua/harpoon-lualine/utils.lua
+++ b/lua/harpoon-lualine/utils.lua
@@ -20,4 +20,8 @@ M.get_full_path = function(root_dir, value)
     return root_dir .. "/" .. value
 end
 
+M.is_relative_path = function(path)
+    return string.sub(path, 1, 1) ~= "/"
+end
+
 return M


### PR DESCRIPTION
## Summary

Detection of an active harpoon entry now works for harpoon entries with absolute paths outside the current working directory.

![image](https://github.com/letieu/harpoon-lualine/assets/3276460/e0c1ddd9-fe6e-4ca6-9754-75b0b52dacb3)

![image](https://github.com/letieu/harpoon-lualine/assets/3276460/e0aa3e46-a662-4b4f-b0ee-7d135a1680f3)

## Issue

When there is a harpoon entry for a path that is not below the current working directory, harpoon adds the entry with its full file path.

In this case, `harpoon-lualine` did not indicate the respective buffer as "active harpoon entry".

## Solution

Adjusted the logic for when the harpoon entry is an absolute file path instead of a relative one.