### PR TITLE
Fix #18: Add special highlight for selected indicator

### DIFF
--- a/lua/harpoon-lualine/init.lua
+++ b/lua/harpoon-lualine/init.lua
@@ -35,27 +35,18 @@ M.status = function(component)
             indicator = component.options.indicators[i]
         end
 
+        local label = indicator
         if type(indicator) == "function" then
-            table.insert(status, indicator(harpoon_entry))
-        elseif type(indicator) == "table" then
-            local label = indicator[1]
-            if type(label) == "function" then
-                label = label(harpoon_entry)
-            end
-
-            if indicator.color then
-                local highlight_group
-                if active then
-                    highlight_group = component.hl_active_indicators[i]
-                else
-                    highlight_group = component.hl_indicators[i]
-                end
-
-                label = highlight.component_format_highlight(highlight_group) .. label
-            end
-        else
-            table.insert(status, indicator)
+            label = indicator(harpoon_entry)
         end
+
+        if component.options.color_active and active then
+            label = highlight.component_format_highlight(component.color_active_hl)
+                .. label
+                .. component:get_default_hl()
+        end
+
+        table.insert(status, label)
     end
 
     return table.concat(status, component.options._separator)

--- a/lua/harpoon-lualine/init.lua
+++ b/lua/harpoon-lualine/init.lua
@@ -1,14 +1,15 @@
 local utils = require "harpoon-lualine.utils"
 local harpoon = utils.lazy_require "harpoon"
+local highlight = require "lualine.highlight"
 
 local M = {}
 
-M.status = function(options)
+M.status = function(component)
     local harpoon_entries = harpoon:list()
     local root_dir = harpoon_entries.config:get_root_dir()
     local current_file_path = vim.api.nvim_buf_get_name(0)
 
-    local length = math.min(harpoon_entries:length(), #options.indicators)
+    local length = math.min(harpoon_entries:length(), #component.options.indicators)
 
     local status = {}
 
@@ -26,21 +27,38 @@ M.status = function(options)
             full_path = harpoon_path
         end
 
+        local active = full_path == current_file_path
         local indicator = nil
-        if full_path == current_file_path then
-            indicator = options.active_indicators[i]
+        if active then
+            indicator = component.options.active_indicators[i]
         else
-            indicator = options.indicators[i]
+            indicator = component.options.indicators[i]
         end
 
         if type(indicator) == "function" then
             table.insert(status, indicator(harpoon_entry))
+        elseif type(indicator) == "table" then
+            local label = indicator[1]
+            if type(label) == "function" then
+                label = label(harpoon_entry)
+            end
+
+            if indicator.color then
+                local highlight_group
+                if active then
+                    highlight_group = component.hl_active_indicators[i]
+                else
+                    highlight_group = component.hl_indicators[i]
+                end
+
+                label = highlight.component_format_highlight(highlight_group) .. label
+            end
         else
             table.insert(status, indicator)
         end
     end
 
-    return table.concat(status, options._separator)
+    return table.concat(status, component.options._separator)
 end
 
 M.setup = function(_)

--- a/lua/lualine/components/harpoon2.lua
+++ b/lua/lualine/components/harpoon2.lua
@@ -1,4 +1,5 @@
 local lualine_require = require "lualine_require"
+local highlight = require "lualine.highlight"
 local M = lualine_require.require("lualine.component"):extend()
 
 local hl = require "harpoon-lualine"
@@ -14,6 +15,38 @@ local default_options = {
 function M:init(options)
     M.super.init(self, options)
     self.options = vim.tbl_deep_extend("keep", self.options or {}, default_options)
+
+    self.hl_indicators = {}
+    for i, indicator in ipairs(self.options.indicators) do
+        if type(indicator) == "table" and indicator.color then
+            table.insert(
+                self.hl_indicators,
+                highlight.create_component_highlight_group(
+                    { fg = indicator.color },
+                    "harpoon_indicator_" .. tostring(i),
+                    self.options
+                )
+            )
+        else
+            table.insert(self.hl_indicators, nil)
+        end
+    end
+
+    self.hl_active_indicators = {}
+    for i, indicator in ipairs(self.options.active_indicators) do
+        if type(indicator) == "table" and indicator.color then
+            table.insert(
+                self.hl_active_indicators,
+                highlight.create_component_highlight_group(
+                    { fg = indicator.color },
+                    "harpoon_active_indicator_" .. tostring(i),
+                    self.options
+                )
+            )
+        else
+            table.insert(self.hl_active_indicators, nil)
+        end
+    end
 end
 
 function M:update_status()

--- a/lua/lualine/components/harpoon2.lua
+++ b/lua/lualine/components/harpoon2.lua
@@ -10,42 +10,16 @@ local default_options = {
     active_indicators = { "[1]", "[2]", "[3]", "[4]" },
     _separator = " ",
     no_harpoon = "Harpoon not loaded",
+    color_active = nil,
 }
 
 function M:init(options)
     M.super.init(self, options)
     self.options = vim.tbl_deep_extend("keep", self.options or {}, default_options)
 
-    self.hl_indicators = {}
-    for i, indicator in ipairs(self.options.indicators) do
-        if type(indicator) == "table" and indicator.color then
-            table.insert(
-                self.hl_indicators,
-                highlight.create_component_highlight_group(
-                    { fg = indicator.color },
-                    "harpoon_indicator_" .. tostring(i),
-                    self.options
-                )
-            )
-        else
-            table.insert(self.hl_indicators, nil)
-        end
-    end
-
-    self.hl_active_indicators = {}
-    for i, indicator in ipairs(self.options.active_indicators) do
-        if type(indicator) == "table" and indicator.color then
-            table.insert(
-                self.hl_active_indicators,
-                highlight.create_component_highlight_group(
-                    { fg = indicator.color },
-                    "harpoon_active_indicator_" .. tostring(i),
-                    self.options
-                )
-            )
-        else
-            table.insert(self.hl_active_indicators, nil)
-        end
+    if self.options.color_active then
+        self.color_active_hl =
+            highlight.create_component_highlight_group(self.options.color_active, "harpoon_active", self.options)
     end
 end
 
@@ -55,7 +29,7 @@ function M:update_status()
         return self.options.no_harpoon
     end
 
-    return hl.status(self.options)
+    return hl.status(self)
 end
 
 return M


### PR DESCRIPTION
Adds the `color_active` option that controls the highlighting of the active indicator.

Example:
```lua
require("lualine").setup({
    sections = {
        -- ...
        {
		"harpoon2",
		color_active = { fg = "#00ff00" },
	},
        -- ...
})
```